### PR TITLE
Change directory to a string

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -50,7 +50,7 @@ yargs(hideBin(process.argv))
   .option('directory', {
     alias: 'D',
     description: 'Path to node_modules.',
-    type: 'boolean',
+    type: 'string',
     default: 'node_modules',
   })
   .option('glob-file', {


### PR DESCRIPTION
Directory path must be a string but it's set to boolean