### PR TITLE
Fix Windows support and add tests for multiple platforms

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,0 +1,16 @@
+name: Run tests on Linux
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Test package
+        run: yarn test

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,0 +1,16 @@
+name: Run tests on MacOS
+
+on: push
+
+jobs:
+  test:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Test package
+        run: yarn test

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,10 +1,10 @@
-name: Run tests
+name: Run tests on Windows
 
 on: push
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ what is used to match file paths under the hood.
 The same type of patterns are accepted by both the `--include`/`--exclude` arguments and the glob
 configuration file.
 
+**Like with .gitignore, globs should use forward-slashes as separators on all operative systems (including Windows)!**
+
 ### Example configuration file
 
 ```ignore

--- a/src/analyze.test.ts
+++ b/src/analyze.test.ts
@@ -1,4 +1,5 @@
 import mockFs from 'mock-fs';
+import path from 'path';
 import { analyzeIncluded } from './analyze';
 import { EMPTY_GLOB_LISTS, getMockedFileStructure } from './__fixtures__/fixtures';
 
@@ -33,19 +34,23 @@ describe('analyzeIncluded', () => {
 
     expect(results).toEqual([
       {
-        filePath: '/node_modules/dep1/__tests__/test1.js',
+        filePath: mockCwd + path.join('node_modules', 'dep1', '__tests__', 'test1.js'),
         includedByDefault: true,
-        includedByGlobs: [{ derived: '/node_modules/**/__tests__/**', original: '__tests__' }],
+        includedByGlobs: [
+          { derived: mockCwd + 'node_modules/**/__tests__/**', original: '__tests__' },
+        ],
       },
       {
-        filePath: '/node_modules/dep1/__tests__/test2.js',
+        filePath: mockCwd + path.join('node_modules', 'dep1', '__tests__', 'test2.js'),
         includedByDefault: true,
-        includedByGlobs: [{ derived: '/node_modules/**/__tests__/**', original: '__tests__' }],
+        includedByGlobs: [
+          { derived: mockCwd + 'node_modules/**/__tests__/**', original: '__tests__' },
+        ],
       },
       {
-        filePath: '/node_modules/dep3/deeply/nested/file.ext',
+        filePath: mockCwd + path.join('node_modules', 'dep3', 'deeply', 'nested', 'file.ext'),
         includedByDefault: false,
-        includedByGlobs: [{ derived: '/node_modules/**/dep3/**', original: 'dep3' }],
+        includedByGlobs: [{ derived: mockCwd + 'node_modules/**/dep3/**', original: 'dep3' }],
       },
     ]);
   });
@@ -69,11 +74,12 @@ describe('analyzeIncluded', () => {
     });
 
     expect(results[0]).toHaveProperty('includedByGlobs', [
-      { derived: '/node_modules/**/file.js', original: 'file.js' },
+      { derived: mockCwd + 'node_modules/**/file.js', original: 'file.js' },
     ]);
+
     expect(results[1]).toHaveProperty('includedByGlobs', [
-      { derived: '/node_modules/**/*.json', original: '*.json' },
-      { derived: '/node_modules/**/tsconfig.json', original: 'tsconfig.json' },
+      { derived: mockCwd + 'node_modules/**/*.json', original: '*.json' },
+      { derived: mockCwd + 'node_modules/**/tsconfig.json', original: 'tsconfig.json' },
     ]);
   });
 });

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { findFilesToRemove } from './clean';
 import { GlobLists } from './types';
 import {
@@ -6,6 +5,7 @@ import {
   optimizeGlobLists,
   parseDefaultGlobsFile,
   toAbsoluteGlobLists,
+  toPosixPath,
 } from './utils/glob';
 
 interface GlobVersions {
@@ -34,7 +34,7 @@ export async function analyzeIncluded(
   });
 
   const globMatchers = globLists.included.map((glob, index) => {
-    const absoluteGlob = path.resolve(nodeModulesPath, glob);
+    const absoluteGlob = toPosixPath(nodeModulesPath) + '/' + glob;
     const matcher = makeGlobMatcher(absoluteGlob);
     return { original: globLists.originalIncluded[index], derived: absoluteGlob, matcher };
   });

--- a/src/clean.test.ts
+++ b/src/clean.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import mockFs from 'mock-fs';
+import path from 'path';
 import { findFilesToRemove, removeEmptyDirs, removeFiles } from './clean';
 import { EMPTY_GLOB_LISTS, getMockedFileStructure } from './__fixtures__/fixtures';
 
@@ -30,13 +31,11 @@ describe('findFilesToRemove', () => {
       includedDirs: ['**/__tests__', '**/dep3'],
     });
 
-    expect(result).toMatchInlineSnapshot(`
-      Array [
-        "/node_modules/dep1/__tests__/test1.js",
-        "/node_modules/dep1/__tests__/test2.js",
-        "/node_modules/dep3/deeply/nested/file.ext",
-      ]
-    `);
+    expect(result).toEqual([
+      mockCwd + path.join('node_modules', 'dep1', '__tests__', 'test1.js'),
+      mockCwd + path.join('node_modules', 'dep1', '__tests__', 'test2.js'),
+      mockCwd + path.join('node_modules', 'dep3', 'deeply', 'nested', 'file.ext'),
+    ]);
   });
 
   it('includes files', async () => {
@@ -45,12 +44,10 @@ describe('findFilesToRemove', () => {
       included: ['**/deeply/nested/file.ext', '**/dep4/**'],
     });
 
-    expect(result).toMatchInlineSnapshot(`
-      Array [
-        "/node_modules/dep4/nonDefaultFile.ext",
-        "/node_modules/dep3/deeply/nested/file.ext",
-      ]
-    `);
+    expect(result).toEqual([
+      mockCwd + path.join('node_modules', 'dep4', 'nonDefaultFile.ext'),
+      mockCwd + path.join('node_modules', 'dep3', 'deeply', 'nested', 'file.ext'),
+    ]);
   });
 
   it('can exclude files and dirs by glob patterns', async () => {
@@ -60,11 +57,7 @@ describe('findFilesToRemove', () => {
       excluded: ['**/test*.js'],
     });
 
-    expect(result).toMatchInlineSnapshot(`
-      Array [
-        "/node_modules/dep2/file.js",
-      ]
-    `);
+    expect(result).toEqual([mockCwd + path.join('node_modules', 'dep2', 'file.js')]);
   });
 });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@ export const DEFAULT_USER_GLOBS_FILE_NAME = '.cleanmodules';
 
 export const DEFAULT_GLOBS_FILE_NAME = '.cleanmodules-default';
 
-export const DEFAULT_GLOBS_FILE_PATH = path.resolve(__dirname, `../${DEFAULT_GLOBS_FILE_NAME}`);
+export const DEFAULT_GLOBS_FILE_PATH = path.resolve(__dirname, '..', DEFAULT_GLOBS_FILE_NAME);
 
 export const DEFAULT_PICO_OPTIONS: Partial<PicomatchOptions> = {
   dot: true,

--- a/src/utils/filesystem.test.ts
+++ b/src/utils/filesystem.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import mockFs from 'mock-fs';
+import path from 'path';
 import {
   crawlDirFast,
   crawlDirWithChecks,
@@ -177,7 +178,12 @@ describe('crawlDirFast', () => {
   it('appends all nested file paths to the provided array', async () => {
     const filePaths: string[] = [];
     await crawlDirFast(filePaths, 'a0');
-    expect(filePaths).toEqual(['a0/b0/c1', 'a0/b0/c2', 'a0/b0/c0/d2', 'a0/b0/c0/d1/e0/f0']);
+    expect(filePaths).toEqual([
+      path.join('a0', 'b0', 'c1'),
+      path.join('a0', 'b0', 'c2'),
+      path.join('a0', 'b0', 'c0', 'd2'),
+      path.join('a0', 'b0', 'c0', 'd1', 'e0', 'f0'),
+    ]);
   });
 
   it('does not throw if path is invalid', async () => {
@@ -232,7 +238,12 @@ describe('crawlDirWithChecks', () => {
 
     await crawlDirWithChecks(filePaths, 'a0', checkDir, checkFile);
 
-    expect(filePaths).toEqual(['a0/b0/c1', 'a0/b0/c2', 'a0/b0/c0/d2', 'a0/b0/c0/d1/e0/f0']);
+    expect(filePaths).toEqual([
+      path.join('a0', 'b0', 'c1'),
+      path.join('a0', 'b0', 'c2'),
+      path.join('a0', 'b0', 'c0', 'd2'),
+      path.join('a0', 'b0', 'c0', 'd1', 'e0', 'f0'),
+    ]);
     expect(checkDir).toHaveBeenCalledTimes(1);
     expect(checkFile).toHaveBeenCalledTimes(0);
   });

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -91,7 +91,7 @@ export async function removeEmptyDirsUp(
  */
 export async function crawlDirFast(filePaths: string[], dirPath: string): Promise<void> {
   await forEachDirentAsync(dirPath, async dirent => {
-    const nextPath = `${dirPath}/${dirent.name}`;
+    const nextPath = dirPath + path.sep + dirent.name;
 
     if (dirent.isDirectory()) {
       await crawlDirFast(filePaths, nextPath);
@@ -111,7 +111,7 @@ export async function crawlDirWithChecks(
   checkFile: CheckPathFunc
 ): Promise<string[]> {
   await forEachDirentAsync(dirPath, async nextPathDirent => {
-    const nextPath = `${dirPath}/${nextPathDirent.name}`;
+    const nextPath = dirPath + path.sep + nextPathDirent.name;
 
     if (nextPathDirent.isDirectory()) {
       if (checkDir(nextPath)) {

--- a/src/utils/glob.test.ts
+++ b/src/utils/glob.test.ts
@@ -91,7 +91,7 @@ describe('mergeGlobLists', () => {
 });
 
 describe('toAbsoluteGlobLists', () => {
-  it('prepends absolute paths to globs lists', () => {
+  it('prepends globs with absolute paths on all platforms', () => {
     const result = toAbsoluteGlobLists(
       {
         ...EMPTY_GLOB_LISTS,

--- a/src/utils/glob.ts
+++ b/src/utils/glob.ts
@@ -52,15 +52,22 @@ export function mergeGlobLists(globListsA: GlobLists, globListsB: GlobLists): Gl
   };
 }
 
+/** Replaces path with forward slashes as separators if necessary. Globs should always have POSIX separators, even on Windows. */
+export function toPosixPath(pathStr: string): string {
+  return path.sep === '/' ? pathStr : pathStr.replace(/\\/g, '/');
+}
+
 /**
- * Appends an absolute path to all editable lists in a GlobLists object.
+ * Prepends an absolute path to all editable lists in a GlobLists object.
  */
 export function toAbsoluteGlobLists(
   globLists: GlobLists,
   absoluteNodeModulesPath: string
 ): GlobLists {
+  const absolutePathWithPosixSeparator = toPosixPath(absoluteNodeModulesPath);
+
   return updateGlobLists(globLists, globs =>
-    globs.map(glob => path.resolve(absoluteNodeModulesPath, glob))
+    globs.map(glob => absolutePathWithPosixSeparator + '/' + glob)
   );
 }
 
@@ -178,6 +185,7 @@ export async function parseGlobsFile(filePath: string): Promise<GlobLists> {
 
   const fileGlobs =
     fileContents.split(/\r?\n/).filter(line => !line.match(COMMENT_OR_EMPTY_REGEX)) || [];
+
   return processGlobs(fileGlobs);
 }
 


### PR DESCRIPTION
Fixes #12, #13

## Context

Globs are not being matched correctly on Windows because:
- file paths should use Windows separators (`\\`)
- glob paths should use POSIX separators (`/`) on all platforms

## Changes

- Ensure file paths keeps platform specific separators.
- Ensure glob paths always use forward-slashes as separators.
- Make tests cross-platform.
- Add Github actions for running tests on multiple platforms.
