### PR TITLE
fix: inject esm/cjs shims and fix import.meta compilation

### DIFF
--- a/.changeset/famous-mangos-thank.md
+++ b/.changeset/famous-mangos-thank.md
@@ -1,0 +1,5 @@
+---
+'clean-modules': patch
+---
+
+Fix `import.meta.url` not being transpiled to an equivalent value for CJS builds.

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -7,7 +7,7 @@ import { CleanCommand } from './commands/clean.command.js';
 
 const [_node, _app, ...args] = process.argv;
 const esmRequire = createRequire(import.meta.url);
-const cliDir = fileDir(import.meta);
+const cliDir = fileDir(import.meta.url);
 const { name, version } = esmRequire(path.resolve(cliDir, '..', '..', 'package.json'));
 
 const cli = new Cli({

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { fileDir } from './utils/filesystem.js';
 
 export const DEFAULT_GLOBS_FILE_PATH = path.resolve(
-  fileDir(import.meta),
+  fileDir(import.meta.url),
   '..',
   '.cleanmodules-default'
 );

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -187,8 +187,8 @@ export async function removeFiles(
 
 /**
  * Get directory of the file directory, like CommonJS `__dirname`.
- * @example const thisFilesDir = fileDir(import.meta);
+ * @example const thisFilesDir = fileDir(import.meta.url);
  */
-export function fileDir(importMeta: ImportMeta) {
-  return path.dirname(fileURLToPath(importMeta.url));
+export function fileDir(importMetaUrl: string) {
+  return path.dirname(fileURLToPath(importMetaUrl));
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
   splitting: true,
   sourcemap: false,
   clean: true,
+  shims: true,
   dts: true,
 });


### PR DESCRIPTION
Fixes #21

## Context

Programmatic usage with with CJS is causing crashes because `import.meta.url` doesn't get transpiled into something that works for CJS. See #21.

## Changes

- set `shims: true` in the tsup config
- pass `import.meta.url` instead of `import.meta` so tsup detects it as a URL
