### PR TITLE
fix(defaults): add glob for `stylelintrc`

### DIFF
--- a/.changeset/polite-clocks-retire.md
+++ b/.changeset/polite-clocks-retire.md
@@ -1,0 +1,5 @@
+---
+'clean-modules': patch
+---
+
+Add `.stylelintrc*(.*)` to `.cleanmodules-default`.

--- a/.cleanmodules-default
+++ b/.cleanmodules-default
@@ -115,6 +115,7 @@ circle.yml
 # linters
 .eslintrc*(.*)
 stylelint.config.js
+.stylelintrc*(.*)
 .htmllintrc*(.*)
 htmllint.js
 .jshintrc*(.*)


### PR DESCRIPTION
Add `.stylelintrc*(.*)` to `.cleanmodules-default`.